### PR TITLE
Add centralized rate-limit-aware GitHub transport

### DIFF
--- a/cmds/add_labels.go
+++ b/cmds/add_labels.go
@@ -21,11 +21,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 	"gomodules.xyz/pointer"
 )
@@ -49,20 +47,8 @@ func NewCmdAddLabels() *cobra.Command {
 }
 
 func addLabels() {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	// Get the current user
 	user, _, err := client.Users.Get(ctx, "")

--- a/cmds/copy_releases.go
+++ b/cmds/copy_releases.go
@@ -26,11 +26,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 )
 
@@ -68,17 +66,9 @@ func copyRelease(src, dest string) {
 	}
 	destOwner, destRepo := parts[0], parts[1]
 
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	// github client
 	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	var buf bytes.Buffer
 
@@ -180,24 +170,12 @@ func ListReleases(ctx context.Context, client *github.Client, owner, repo string
 	var result []*github.RepositoryRelease
 	for {
 		branch, resp, err := client.Repositories.ListReleases(ctx, owner, repo, opt)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
 				break
-			} else {
-				return nil, err
 			}
-		default:
-			if e != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		result = append(result, branch...)

--- a/cmds/del_package.go
+++ b/cmds/del_package.go
@@ -22,12 +22,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"time"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 	"gomodules.xyz/pointer"
 	"gomodules.xyz/sets"
@@ -59,17 +56,9 @@ func NewCmdDeletePackage() *cobra.Command {
 }
 
 func deletePackage(org, pkg, tag string) {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	// github client
 	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	if pkg == "" {
 		deleteAllOrgPackages(ctx, client, org)
@@ -155,24 +144,12 @@ func ListPackages(ctx context.Context, client *github.Client, owner, visibility 
 	var result []*github.Package
 	for {
 		versions, resp, err := client.Organizations.ListPackages(ctx, owner, opt)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
 				break
-			} else {
-				return nil, err
 			}
-		default:
-			if e != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		result = append(result, versions...)
@@ -194,24 +171,12 @@ func ListPackageVersions(ctx context.Context, client *github.Client, owner, pkg 
 	var result []*github.PackageVersion
 	for {
 		versions, resp, err := client.Organizations.PackageGetAllVersions(ctx, owner, "container", pkg, opt)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
 				break
-			} else {
-				return nil, err
 			}
-		default:
-			if e != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		result = append(result, versions...)

--- a/cmds/del_release.go
+++ b/cmds/del_release.go
@@ -20,12 +20,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
-	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 )
 
@@ -56,17 +53,9 @@ func deleteRelease(src string) {
 	}
 	srcOwner, srcRepo := parts[0], parts[1]
 
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	// github client
 	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	srcReleases, err := ListReleases(ctx, client, srcOwner, srcRepo)
 	if err != nil {

--- a/cmds/dependabot.go
+++ b/cmds/dependabot.go
@@ -21,11 +21,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 )
 
@@ -55,20 +53,8 @@ func NewCmdDependabot() *cobra.Command {
 }
 
 func addDependabot() {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	// Get the current user
 	user, _, err := client.Users.Get(ctx, "")

--- a/cmds/github_client.go
+++ b/cmds/github_client.go
@@ -91,8 +91,8 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 			return resp, nil
 		}
 
-		delay, ok := rateLimitRetryDelay(resp, attempt)
-		if !ok || attempt >= maxRateLimitRetryAttempts {
+		delay := rateLimitRetryDelay(resp, attempt)
+		if attempt >= maxRateLimitRetryAttempts {
 			return resp, nil
 		}
 		if !canRetryBody {
@@ -115,32 +115,25 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 	}
 }
 
-func rateLimitRetryDelay(resp *http.Response, secondaryAttempt int) (time.Duration, bool) {
+func rateLimitRetryDelay(resp *http.Response, secondaryAttempt int) time.Duration {
 	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
 	if retryAfter > 0 {
-		return retryAfter, true
+		return retryAfter
 	}
 
 	remaining := resp.Header.Get("X-RateLimit-Remaining")
 	if remaining == "0" {
 		if reset := parseUnixTime(resp.Header.Get("X-RateLimit-Reset")); !reset.IsZero() {
-			delay := time.Until(reset) + time.Second
-			if delay < time.Second {
-				delay = time.Second
-			}
-			return delay, true
+			return max(time.Until(reset)+time.Second, time.Second)
 		}
 	}
 
 	// Secondary limit guidance from GitHub docs: wait at least 1 minute and increase with backoff.
-	backoff := time.Duration(float64(defaultSecondaryRetryDelay) * math.Pow(2, float64(secondaryAttempt)))
-	if backoff > maxSecondaryRetryDelay {
-		backoff = maxSecondaryRetryDelay
-	}
+	backoff := min(time.Duration(float64(defaultSecondaryRetryDelay)*math.Pow(2, float64(secondaryAttempt))), maxSecondaryRetryDelay)
 	if backoff < time.Second {
 		backoff = time.Second
 	}
-	return backoff, true
+	return backoff
 }
 
 func parseRetryAfter(value string) time.Duration {
@@ -155,10 +148,7 @@ func parseRetryAfter(value string) time.Duration {
 		return time.Duration(seconds) * time.Second
 	}
 	if ts, err := http.ParseTime(value); err == nil {
-		d := time.Until(ts)
-		if d < time.Second {
-			d = time.Second
-		}
+		d := max(time.Until(ts), time.Second)
 		return d
 	}
 	return 0

--- a/cmds/github_client.go
+++ b/cmds/github_client.go
@@ -1,0 +1,176 @@
+/*
+Copyright AppsCode Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmds
+
+import (
+	"context"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/google/go-github/v84/github"
+	"golang.org/x/oauth2"
+)
+
+const (
+	defaultSecondaryRetryDelay = time.Minute
+	maxSecondaryRetryDelay     = 15 * time.Minute
+	maxRateLimitRetryAttempts  = 8
+)
+
+func newGitHubClient(ctx context.Context) *github.Client {
+	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
+	if !found {
+		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
+	}
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	httpClient := oauth2.NewClient(ctx, ts)
+
+	baseTransport := httpClient.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	httpClient.Transport = &rateLimitTransport{base: baseTransport}
+
+	return github.NewClient(httpClient)
+}
+
+type rateLimitTransport struct {
+	base http.RoundTripper
+}
+
+func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.GetBody == nil {
+		if f, ok := req.Body.(*os.File); ok {
+			name := f.Name()
+			req.GetBody = func() (io.ReadCloser, error) {
+				return os.Open(name)
+			}
+		}
+	}
+
+	canRetryBody := req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+
+	for attempt := 0; ; attempt++ {
+		currReq := req
+		if attempt > 0 {
+			currReq = req.Clone(req.Context())
+			if req.GetBody != nil {
+				body, err := req.GetBody()
+				if err != nil {
+					return nil, err
+				}
+				currReq.Body = body
+			}
+		}
+
+		resp, err := t.base.RoundTrip(currReq)
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil || (resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests) {
+			return resp, nil
+		}
+
+		delay, ok := rateLimitRetryDelay(resp, attempt)
+		if !ok || attempt >= maxRateLimitRetryAttempts {
+			return resp, nil
+		}
+		if !canRetryBody {
+			return resp, nil
+		}
+
+		log.Printf("GitHub API rate limited (%d), waiting %s before retry", resp.StatusCode, delay.Round(time.Second))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-req.Context().Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, req.Context().Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func rateLimitRetryDelay(resp *http.Response, secondaryAttempt int) (time.Duration, bool) {
+	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+	if retryAfter > 0 {
+		return retryAfter, true
+	}
+
+	remaining := resp.Header.Get("X-RateLimit-Remaining")
+	if remaining == "0" {
+		if reset := parseUnixTime(resp.Header.Get("X-RateLimit-Reset")); !reset.IsZero() {
+			delay := time.Until(reset) + time.Second
+			if delay < time.Second {
+				delay = time.Second
+			}
+			return delay, true
+		}
+	}
+
+	// Secondary limit guidance from GitHub docs: wait at least 1 minute and increase with backoff.
+	backoff := time.Duration(float64(defaultSecondaryRetryDelay) * math.Pow(2, float64(secondaryAttempt)))
+	if backoff > maxSecondaryRetryDelay {
+		backoff = maxSecondaryRetryDelay
+	}
+	if backoff < time.Second {
+		backoff = time.Second
+	}
+	return backoff, true
+}
+
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	seconds, err := strconv.Atoi(value)
+	if err == nil {
+		if seconds < 1 {
+			seconds = 1
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if ts, err := http.ParseTime(value); err == nil {
+		d := time.Until(ts)
+		if d < time.Second {
+			d = time.Second
+		}
+		return d
+	}
+	return 0
+}
+
+func parseUnixTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	sec, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(sec, 0).UTC()
+}

--- a/cmds/list_orgs.go
+++ b/cmds/list_orgs.go
@@ -20,11 +20,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 )
 
@@ -46,20 +44,8 @@ func NewCmdListOrgs() *cobra.Command {
 }
 
 func runListOrgs() {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	// Get the current user
 	user, _, err := client.Users.Get(ctx, "")

--- a/cmds/list_repos.go
+++ b/cmds/list_repos.go
@@ -20,12 +20,10 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"sort"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/sets"
 )
 
@@ -49,20 +47,8 @@ func NewCmdListRepos() *cobra.Command {
 }
 
 func printRepoList(orgs sets.String, orgOwned, fork, ssh bool) {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	var listing []string
 	if orgOwned {

--- a/cmds/protect.go
+++ b/cmds/protect.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -30,13 +29,11 @@ import (
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 	"gomodules.xyz/sets"
 )
 
 const (
-	skew            = 10 * time.Second
 	teamReviewers   = "reviewers"
 	teamFEReviewers = "fe-reviewers" // frontend
 	teamBEReviewers = "be-reviewers" // backend
@@ -72,20 +69,8 @@ func NewCmdProtect() *cobra.Command {
 }
 
 func runProtect() {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	// Get the current user
 	user, _, err := client.Users.Get(ctx, "")
@@ -197,26 +182,13 @@ func ListOrgs(ctx context.Context, client *github.Client, opt *github.ListOption
 	var result []*github.Organization
 	for {
 		orgs, resp, err := client.Organizations.List(ctx, "", opt)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
 				break
-			} else {
-				return nil, err
 			}
-		default:
-			if e != nil {
-				return nil, err
-			}
+			return nil, err
 		}
-
 		result = append(result, orgs...)
 		if resp.NextPage == 0 {
 			break
@@ -244,24 +216,12 @@ func ListRepos(ctx context.Context, client *github.Client, opt *github.Repositor
 	var result []*github.Repository
 	for {
 		repos, resp, err := client.Repositories.ListByAuthenticatedUser(ctx, opt)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
 				break
-			} else {
-				return nil, err
 			}
-		default:
-			if e != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		for idx := range repos {
@@ -285,24 +245,12 @@ func ListOrgRepos(ctx context.Context, client *github.Client, org string, opt *g
 	var result []*github.Repository
 	for {
 		repos, resp, err := client.Repositories.ListByOrg(ctx, org, opt)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
 				break
-			} else {
-				return nil, err
 			}
-		default:
-			if e != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		for idx := range repos {
@@ -332,24 +280,12 @@ func ListBranches(ctx context.Context, client *github.Client, repo *github.Repos
 	var result []*github.Branch
 	for {
 		branch, resp, err := client.Repositories.ListBranches(ctx, repo.Owner.GetLogin(), repo.GetName(), opt)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
+		if err != nil {
+			if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
 				log.Println(err)
 				break
-			} else {
-				return nil, err
 			}
-		default:
-			if e != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 
 		result = append(result, branch...)
@@ -372,16 +308,7 @@ func ProtectRepo(ctx context.Context, client *github.Client, repo *github.Reposi
 			strings.HasPrefix(branch.GetName(), "kubernetes-") ||
 			strings.HasPrefix(branch.GetName(), "ac-") {
 			if err := ProtectBranch(ctx, client, repo.Owner.GetLogin(), repo.GetName(), branch.GetName(), repo.GetPrivate()); err != nil {
-				switch e := err.(type) {
-				case *github.RateLimitError:
-					time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-					continue
-				case *github.AbuseRateLimitError:
-					time.Sleep(e.GetRetryAfter())
-					continue
-				case *github.ErrorResponse:
-					log.Println("error", err)
-				}
+				log.Println("error", err)
 				return nil // ignore error
 			}
 		}
@@ -495,83 +422,42 @@ func ProtectBranch(ctx context.Context, client *github.Client, owner, repo, bran
 }
 
 func TeamMaintainsRepo(ctx context.Context, client *github.Client, org, team, repo string) error {
-	for {
-		_, err := client.Teams.AddTeamRepoBySlug(ctx, org, team, org, repo, &github.TeamAddTeamRepoOptions{
-			Permission: "admin",
-		})
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
-				log.Println(err)
-				break
-			} else {
-				return err
-			}
-		default:
-			if e != nil {
-				return err
-			}
+	_, err := client.Teams.AddTeamRepoBySlug(ctx, org, team, org, repo, &github.TeamAddTeamRepoOptions{
+		Permission: "admin",
+	})
+	if err != nil {
+		if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
+			log.Println(err)
+			return nil
 		}
-		return nil
+		return err
 	}
+	return nil
 }
 
 func CreateTeamIfMissing(ctx context.Context, client *github.Client, org, team string) (int64, error) {
-GET_TEAM:
-	for {
-		t, _, err := client.Teams.GetTeamBySlug(ctx, org, team)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
-				log.Println(err)
-				break GET_TEAM
-			} else {
-				return 0, err
-			}
-		default:
-			if e != nil {
-				return 0, err
-			}
+	t, _, err := client.Teams.GetTeamBySlug(ctx, org, team)
+	if err != nil {
+		if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
+			log.Println(err)
+		} else {
+			return 0, err
 		}
+	} else {
 		return t.GetID(), nil // team exists
 	}
 
 	privacy := "closed"
-	for {
-		t, _, err := client.Teams.CreateTeam(ctx, org, github.NewTeam{
-			Name: team,
-			Maintainers: []string{
-				"tamalsaha",
-				"1gtm",
-			},
-			Privacy: &privacy,
-		})
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			return 0, err
-		default:
-			if e != nil {
-				return 0, err
-			}
-		}
-		return t.GetID(), nil
+	t, _, err = client.Teams.CreateTeam(ctx, org, github.NewTeam{
+		Name: team,
+		Maintainers: []string{
+			"tamalsaha",
+			"1gtm",
+		},
+		Privacy: &privacy,
+	})
+	if err != nil {
+		return 0, err
 	}
+	return t.GetID(), nil
 }

--- a/cmds/protect_org.go
+++ b/cmds/protect_org.go
@@ -20,12 +20,10 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 	"gomodules.xyz/sets"
 )
@@ -59,20 +57,8 @@ func runProtectOrg(org string, includeForks bool, skipList []string) {
 		log.Fatal("--org flag is required")
 	}
 
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	// Get the current user
 	user, _, err := client.Users.Get(ctx, "")

--- a/cmds/protect_repo.go
+++ b/cmds/protect_repo.go
@@ -20,12 +20,9 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"os"
-	"time"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 )
 
@@ -51,20 +48,8 @@ func NewCmdProtectRepo() *cobra.Command {
 }
 
 func runProtectRepo(owner, repo string) {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	r, err := GetRepo(ctx, client, owner, repo)
 	if err != nil {
@@ -78,28 +63,13 @@ func runProtectRepo(owner, repo string) {
 }
 
 func GetRepo(ctx context.Context, client *github.Client, owner, repo string) (*github.Repository, error) {
-	for {
-		repo, _, err := client.Repositories.Get(ctx, owner, repo)
-		switch e := err.(type) {
-		case *github.RateLimitError:
-			time.Sleep(time.Until(e.Rate.Reset.Add(skew)))
-			continue
-		case *github.AbuseRateLimitError:
-			time.Sleep(e.GetRetryAfter())
-			continue
-		case *github.ErrorResponse:
-			if e.Response.StatusCode == http.StatusNotFound {
-				log.Println(err)
-				break
-			} else {
-				return nil, err
-			}
-		default:
-			if e != nil {
-				return nil, err
-			}
+	r, _, err := client.Repositories.Get(ctx, owner, repo)
+	if err != nil {
+		if e, ok := err.(*github.ErrorResponse); ok && e.Response.StatusCode == http.StatusNotFound {
+			log.Println(err)
+			return nil, nil
 		}
-
-		return repo, nil
+		return nil, err
 	}
+	return r, nil
 }

--- a/cmds/release.go
+++ b/cmds/release.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 )
 
@@ -62,17 +61,9 @@ func runRelease(owner, repo string, draft, prerelease bool) {
 		log.Fatal("Repository name can't be empty")
 	}
 
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	// github client
 	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	tag, err := git.Clean(git.Run("tag", "-l", "--points-at", "HEAD"))
 	if err != nil {

--- a/cmds/start_report.go
+++ b/cmds/start_report.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 )
 
@@ -51,20 +50,8 @@ func NewCmdStarReport() *cobra.Command {
 }
 
 func runStarReport() {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	// Get the current user
 	user, _, err := client.Users.Get(ctx, "")

--- a/cmds/unwatch.go
+++ b/cmds/unwatch.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/google/go-github/v84/github"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
 	"gomodules.xyz/flags"
 )
 
@@ -49,24 +48,12 @@ func NewCmdStopWatch() *cobra.Command {
 }
 
 func runStopWatch() {
-	token, found := os.LookupEnv("GH_TOOLS_TOKEN")
-	if !found {
-		log.Fatalln("GH_TOOLS_TOKEN env var is not set")
-	}
-
 	if len(orgsToWatchRepos) == 0 {
 		os.Exit(0)
 	}
 
 	ctx := context.Background()
-
-	// Create the http client.
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
-
-	client := github.NewClient(tc)
+	client := newGitHubClient(ctx)
 
 	// Get the current user
 	user, _, err := client.Users.Get(ctx, "")


### PR DESCRIPTION
All GitHub API calls now go through a shared `rateLimitTransport` HTTP transport (`cmds/github_client.go`) that automatically waits and retries when the API responds with 403 or 429, per the [GitHub REST API rate limit docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api):

- `Retry-After` header is honored first (covers both primary and secondary limits)
- `X-RateLimit-Reset` is used when `X-RateLimit-Remaining` is `0`
- Otherwise exponential backoff starting at 1 minute, capped at 15 minutes
- Requests with replayable bodies (nil, `NoBody`, `GetBody` set, or `*os.File`) are retried up to 8 times; non-replayable bodies return the rate-limit response unchanged
- Context cancellation is respected during waits

All command entrypoints call `newGitHubClient(ctx)` instead of constructing oauth2/github clients inline.

Redundant per-function `RateLimitError`/`AbuseRateLimitError` retry loops removed from: `ListOrgs`, `ListRepos`, `ListOrgRepos`, `ListBranches`, `ListReleases`, `ListPackages`, `ListPackageVersions`, `GetRepo`, `TeamMaintainsRepo`, `CreateTeamIfMissing`.

The `skew` constant is removed as it is no longer needed.

Signed-off-by: Tamal Saha <tamal@appscode.com>