### PR TITLE
Configure Dependabot alerts in protect commands

### DIFF
--- a/cmds/protect.go
+++ b/cmds/protect.go
@@ -145,6 +145,11 @@ func runProtect() {
 				continue // don't protect personal repos
 			}
 			if repo.GetPermissions().GetAdmin() {
+				err = ConfigureDependabotAlertsNoAutoPRs(ctx, client, repo)
+				if err != nil {
+					log.Fatalln(err)
+				}
+
 				// for appscode org, add repos by hand to team
 				if repo.GetOwner().GetLogin() != "appscode" {
 					err = TeamMaintainsRepo(ctx, client, repo.GetOwner().GetLogin(), teamReviewers, repo.GetName())
@@ -313,6 +318,24 @@ func ProtectRepo(ctx context.Context, client *github.Client, repo *github.Reposi
 			}
 		}
 	}
+	return nil
+}
+
+func ConfigureDependabotAlertsNoAutoPRs(ctx context.Context, client *github.Client, repo *github.Repository) error {
+	if repo == nil || repo.Owner == nil {
+		return fmt.Errorf("invalid repo object")
+	}
+
+	owner := repo.Owner.GetLogin()
+	name := repo.GetName()
+
+	if _, err := client.Repositories.EnableVulnerabilityAlerts(ctx, owner, name); err != nil {
+		return err
+	}
+	if _, err := client.Repositories.DisableAutomatedSecurityFixes(ctx, owner, name); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cmds/protect_org.go
+++ b/cmds/protect_org.go
@@ -110,6 +110,11 @@ func runProtectOrg(org string, includeForks bool, skipList []string) {
 			continue
 		}
 
+		err = ConfigureDependabotAlertsNoAutoPRs(ctx, client, repo)
+		if err != nil {
+			log.Fatalln(err)
+		}
+
 		// For appscode org, repos are added to team manually
 		if org != "appscode" {
 			err = TeamMaintainsRepo(ctx, client, org, teamReviewers, repo.GetName())

--- a/cmds/protect_repo.go
+++ b/cmds/protect_repo.go
@@ -18,6 +18,7 @@ package cmds
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -52,6 +53,14 @@ func runProtectRepo(owner, repo string) {
 	client := newGitHubClient(ctx)
 
 	r, err := GetRepo(ctx, client, owner, repo)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	if r == nil {
+		log.Fatalln(fmt.Errorf("repository %s/%s not found", owner, repo))
+	}
+
+	err = ConfigureDependabotAlertsNoAutoPRs(ctx, client, r)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
This updates protect command flows to configure Dependabot security posture per repository while applying branch protection.

Changes:
- protect, protect-org, and protect-repo now call a shared helper that:
  - enables Dependabot vulnerability alerts
  - disables automated security fix PR creation
- keeps existing branch protection behavior unchanged

Notes:
- The GitHub REST API does not expose a direct setting to force Dependabot alert refresh cadence to hourly via this toolchain.
- Alert scanning cadence is managed by GitHub; this change ensures alerts are enabled and auto-PRs are not generated.

Signed-off-by: Tamal Saha <tamal@appscode.com>
