### PR TITLE
Make dependabot command disable auto-fix PRs by default

### DIFF
--- a/cmds/dependabot.go
+++ b/cmds/dependabot.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	enableDependabot    = true
-	enableSecurityFixes = true
+	enableSecurityFixes = false
 )
 
 func NewCmdDependabot() *cobra.Command {
@@ -114,6 +114,10 @@ func processDependabot(ctx context.Context, client *github.Client, repo *github.
 		}
 		if enableSecurityFixes {
 			if _, err := client.Repositories.EnableAutomatedSecurityFixes(ctx, repo.Owner.GetLogin(), repo.GetName()); err != nil {
+				return err
+			}
+		} else {
+			if _, err := client.Repositories.DisableAutomatedSecurityFixes(ctx, repo.Owner.GetLogin(), repo.GetName()); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This updates the dependabot command behavior so repositories can have Dependabot vulnerability alerts enabled without automatically creating security-fix PRs.

Changes:
- set enableSecurityFixes default to false
- when --enable=true and --autofix=false, explicitly call DisableAutomatedSecurityFixes
- keep vulnerability alerts enabled via EnableVulnerabilityAlerts

Result:
- running the command now enforces alerts on while avoiding automatic security-fix PR generation unless explicitly requested with --autofix=true.

Signed-off-by: Tamal Saha <tamal@appscode.com>
