### PR TITLE
Increase max secondary retry delay to 60 minutes

### DIFF
--- a/cmds/github_client.go
+++ b/cmds/github_client.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	defaultSecondaryRetryDelay = time.Minute
-	maxSecondaryRetryDelay     = 15 * time.Minute
+	maxSecondaryRetryDelay     = 60 * time.Minute
 	maxRateLimitRetryAttempts  = 8
 )
 


### PR DESCRIPTION
## Summary
- Increase max secondary retry delay from 15 minutes to 60 minutes to handle longer rate limit windows