### PR TITLE
Log retry wait from rate limit headers

### DIFF
--- a/cmds/github_client.go
+++ b/cmds/github_client.go
@@ -113,7 +113,7 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 			if requestedWait, requestedFrom, ok := requestedRateLimitWait(resp); ok {
 				log.Printf("GitHub API rate limited (%d), waiting %s before retry (%s). GitHub asked to wait %s (%s)", resp.StatusCode, delay.Round(time.Second), retryHint, requestedWait.Round(time.Second), requestedFrom)
 			} else {
-				log.Printf("GitHub API rate limited (%d), waiting %s before retry (%s). GitHub did not specify a wait duration in headers", resp.StatusCode, delay.Round(time.Second), retryHint)
+				log.Printf("GitHub API rate limited (%d), waiting %s before retry (%s)", resp.StatusCode, delay.Round(time.Second), retryHint)
 			}
 		}
 		_, _ = io.Copy(io.Discard, resp.Body)

--- a/cmds/github_client.go
+++ b/cmds/github_client.go
@@ -110,7 +110,11 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 		if resp.StatusCode == http.StatusInternalServerError {
 			log.Printf("GitHub API server error (500), waiting %s before retry", delay.Round(time.Second))
 		} else {
-			log.Printf("GitHub API rate limited (%d), waiting %s before retry (%s)", resp.StatusCode, delay.Round(time.Second), retryHint)
+			if requestedWait, requestedFrom, ok := requestedRateLimitWait(resp); ok {
+				log.Printf("GitHub API rate limited (%d), waiting %s before retry (%s). GitHub asked to wait %s (%s)", resp.StatusCode, delay.Round(time.Second), retryHint, requestedWait.Round(time.Second), requestedFrom)
+			} else {
+				log.Printf("GitHub API rate limited (%d), waiting %s before retry (%s). GitHub did not specify a wait duration in headers", resp.StatusCode, delay.Round(time.Second), retryHint)
+			}
 		}
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
@@ -161,6 +165,22 @@ func rateLimitRetryDelay(resp *http.Response, secondaryAttempt int) (time.Durati
 	// Secondary limit guidance from GitHub docs: wait at least 1 minute and increase with backoff.
 	backoff := max(min(time.Duration(float64(defaultSecondaryRetryDelay)*math.Pow(2, float64(secondaryAttempt))), maxSecondaryRetryDelay), time.Second)
 	return backoff, "using secondary rate-limit backoff"
+}
+
+func requestedRateLimitWait(resp *http.Response) (time.Duration, string, bool) {
+	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+	if retryAfter > 0 {
+		return retryAfter, "Retry-After header", true
+	}
+
+	remaining := resp.Header.Get("X-RateLimit-Remaining")
+	if remaining == "0" {
+		if reset := parseUnixTime(resp.Header.Get("X-RateLimit-Reset")); !reset.IsZero() {
+			return max(time.Until(reset), time.Second), "X-RateLimit-Reset header", true
+		}
+	}
+
+	return 0, "", false
 }
 
 func parseRetryAfter(value string) time.Duration {

--- a/cmds/github_client.go
+++ b/cmds/github_client.go
@@ -99,6 +99,7 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 		}
 
 		delay := retryDelay(resp, attempt)
+		retryHint := retryDelayHint(resp, attempt)
 		if attempt >= maxRateLimitRetryAttempts {
 			return resp, nil
 		}
@@ -109,7 +110,7 @@ func (t *rateLimitTransport) RoundTrip(req *http.Request) (*http.Response, error
 		if resp.StatusCode == http.StatusInternalServerError {
 			log.Printf("GitHub API server error (500), waiting %s before retry", delay.Round(time.Second))
 		} else {
-			log.Printf("GitHub API rate limited (%d), waiting %s before retry", resp.StatusCode, delay.Round(time.Second))
+			log.Printf("GitHub API rate limited (%d), waiting %s before retry (%s)", resp.StatusCode, delay.Round(time.Second), retryHint)
 		}
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
@@ -132,25 +133,34 @@ func retryDelay(resp *http.Response, attempt int) time.Duration {
 		backoff := min(time.Duration(float64(defaultServerErrorDelay)*math.Pow(2, float64(attempt))), maxSecondaryRetryDelay)
 		return max(backoff, time.Second)
 	}
-	return rateLimitRetryDelay(resp, attempt)
+	delay, _ := rateLimitRetryDelay(resp, attempt)
+	return delay
 }
 
-func rateLimitRetryDelay(resp *http.Response, secondaryAttempt int) time.Duration {
+func retryDelayHint(resp *http.Response, secondaryAttempt int) string {
+	if resp.StatusCode == http.StatusInternalServerError {
+		return "exponential backoff after 500 response"
+	}
+	_, hint := rateLimitRetryDelay(resp, secondaryAttempt)
+	return hint
+}
+
+func rateLimitRetryDelay(resp *http.Response, secondaryAttempt int) (time.Duration, string) {
 	retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
 	if retryAfter > 0 {
-		return retryAfter
+		return retryAfter, "from Retry-After header"
 	}
 
 	remaining := resp.Header.Get("X-RateLimit-Remaining")
 	if remaining == "0" {
 		if reset := parseUnixTime(resp.Header.Get("X-RateLimit-Reset")); !reset.IsZero() {
-			return max(time.Until(reset)+time.Second, time.Second)
+			return max(time.Until(reset)+time.Second, time.Second), "from X-RateLimit-Reset header"
 		}
 	}
 
 	// Secondary limit guidance from GitHub docs: wait at least 1 minute and increase with backoff.
 	backoff := max(min(time.Duration(float64(defaultSecondaryRetryDelay)*math.Pow(2, float64(secondaryAttempt))), maxSecondaryRetryDelay), time.Second)
-	return backoff
+	return backoff, "using secondary rate-limit backoff"
 }
 
 func parseRetryAfter(value string) time.Duration {


### PR DESCRIPTION
## Summary
- improve GitHub API rate-limit retry logging
- print how long the client will wait before retrying
- indicate whether the retry delay came from Retry-After, X-RateLimit-Reset, or secondary backoff guidance

## Validation
- go test ./cmds/...
