### PR TITLE
Skip unsupported repos in protect and unprotect commands

### DIFF
--- a/cmds/protect.go
+++ b/cmds/protect.go
@@ -145,16 +145,21 @@ func runProtect() {
 				continue // don't protect personal repos
 			}
 			if repo.GetPermissions().GetAdmin() {
+				supported, reason, err := repoSupportsProtection(ctx, client, repo)
+				if err != nil {
+					log.Fatalln(err)
+				}
+				if !supported {
+					log.Printf("Skipping %s (%s)", repo.GetFullName(), reason)
+					continue
+				}
+
 				// for appscode org, add repos by hand to team
 				if repo.GetOwner().GetLogin() != "appscode" {
 					err = TeamMaintainsRepo(ctx, client, repo.GetOwner().GetLogin(), teamReviewers, repo.GetName())
 					if err != nil {
 						log.Fatalln(err)
 					}
-				}
-
-				if freeOrgs[repo.GetOwner().GetLogin()] && repo.GetPrivate() {
-					continue
 				}
 				if skipRepos.Has(repo.GetFullName()) {
 					continue

--- a/cmds/protect.go
+++ b/cmds/protect.go
@@ -109,7 +109,7 @@ func runProtect() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			freeOrgs[r.GetLogin()] = r.GetPlan().GetName() == "free"
+			cacheOrgFreePlan(r.GetLogin(), r.GetPlan().GetName() == "free")
 
 			if r.GetLogin() == "appscode" {
 				_, err = CreateTeamIfMissing(ctx, client, r.GetLogin(), teamBEReviewers)

--- a/cmds/protect_org.go
+++ b/cmds/protect_org.go
@@ -72,6 +72,7 @@ func runProtectOrg(org string, includeForks bool, skipList []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	cacheOrgFreePlan(org, orgInfo.GetPlan().GetName() == "free")
 	fmt.Printf(">>> Processing org: %s (plan: %s)\n", org, orgInfo.GetPlan().GetName())
 
 	// Create reviewers team if missing

--- a/cmds/protect_org.go
+++ b/cmds/protect_org.go
@@ -72,7 +72,6 @@ func runProtectOrg(org string, includeForks bool, skipList []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	isFreeOrg := orgInfo.GetPlan().GetName() == "free"
 	fmt.Printf(">>> Processing org: %s (plan: %s)\n", org, orgInfo.GetPlan().GetName())
 
 	// Create reviewers team if missing
@@ -110,18 +109,21 @@ func runProtectOrg(org string, includeForks bool, skipList []string) {
 			continue
 		}
 
+		supported, reason, err := repoSupportsProtection(ctx, client, repo)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		if !supported {
+			log.Printf("Skipping %s (%s)", repo.GetFullName(), reason)
+			continue
+		}
+
 		// For appscode org, repos are added to team manually
 		if org != "appscode" {
 			err = TeamMaintainsRepo(ctx, client, org, teamReviewers, repo.GetName())
 			if err != nil {
 				log.Fatalln(err)
 			}
-		}
-
-		// Skip private repos on free orgs (no branch protection available)
-		if isFreeOrg && repo.GetPrivate() {
-			log.Printf("Skipping %s (private repo on free org)", repo.GetFullName())
-			continue
 		}
 
 		if skipRepos.Has(repo.GetName()) {

--- a/cmds/protect_repo.go
+++ b/cmds/protect_repo.go
@@ -55,6 +55,19 @@ func runProtectRepo(owner, repo string) {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	if r == nil {
+		log.Printf("repository not found: %s/%s", owner, repo)
+		return
+	}
+
+	supported, reason, err := repoSupportsProtection(ctx, client, r)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	if !supported {
+		log.Printf("Skipping %s (%s)", r.GetFullName(), reason)
+		return
+	}
 
 	err = ProtectRepo(ctx, client, r)
 	if err != nil {

--- a/cmds/repo_support.go
+++ b/cmds/repo_support.go
@@ -22,6 +22,10 @@ import (
 	"github.com/google/go-github/v84/github"
 )
 
+func cacheOrgFreePlan(org string, isFree bool) {
+	freeOrgs[org] = isFree
+}
+
 func repoSupportsProtection(ctx context.Context, client *github.Client, repo *github.Repository) (bool, string, error) {
 	if repo == nil {
 		return false, "repository not found", nil
@@ -55,6 +59,6 @@ func orgUsesFreePlan(ctx context.Context, client *github.Client, org string) (bo
 	}
 
 	isFree := orgInfo.GetPlan().GetName() == "free"
-	freeOrgs[org] = isFree
+	cacheOrgFreePlan(org, isFree)
 	return isFree, nil
 }

--- a/cmds/repo_support.go
+++ b/cmds/repo_support.go
@@ -1,0 +1,60 @@
+/*
+Copyright AppsCode Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmds
+
+import (
+	"context"
+
+	"github.com/google/go-github/v84/github"
+)
+
+func repoSupportsProtection(ctx context.Context, client *github.Client, repo *github.Repository) (bool, string, error) {
+	if repo == nil {
+		return false, "repository not found", nil
+	}
+	if !repo.GetPrivate() {
+		return true, "", nil
+	}
+	if repo.GetOwner().GetType() == OwnerTypeUser {
+		return false, "private user repositories do not support this feature", nil
+	}
+
+	isFreeOrg, err := orgUsesFreePlan(ctx, client, repo.GetOwner().GetLogin())
+	if err != nil {
+		return false, "", err
+	}
+	if isFreeOrg {
+		return false, "private repositories in GitHub Free organizations do not support this feature", nil
+	}
+
+	return true, "", nil
+}
+
+func orgUsesFreePlan(ctx context.Context, client *github.Client, org string) (bool, error) {
+	if isFree, ok := freeOrgs[org]; ok {
+		return isFree, nil
+	}
+
+	orgInfo, _, err := client.Organizations.Get(ctx, org)
+	if err != nil {
+		return false, err
+	}
+
+	isFree := orgInfo.GetPlan().GetName() == "free"
+	freeOrgs[org] = isFree
+	return isFree, nil
+}

--- a/cmds/unprotect.go
+++ b/cmds/unprotect.go
@@ -177,6 +177,10 @@ func runUnprotectOrg(org string, includeForks bool, skipList []string, rules []s
 	}
 	log.Println("user:", user.GetLogin())
 
+	if _, err := orgUsesFreePlan(ctx, client, org); err != nil {
+		log.Fatalln(err)
+	}
+
 	opt := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{PerPage: 50},
 	}

--- a/cmds/unprotect.go
+++ b/cmds/unprotect.go
@@ -96,6 +96,14 @@ func runUnprotect(rules []string, includeFork bool, skipRepos []string, localSha
 		if !repo.GetPermissions().GetAdmin() {
 			continue
 		}
+		supported, reason, err := repoSupportsProtection(ctx, client, repo)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		if !supported {
+			log.Printf("Skipping %s (%s)", repo.GetFullName(), reason)
+			continue
+		}
 		if skipSet.Has(repo.GetFullName()) {
 			continue
 		}
@@ -127,6 +135,15 @@ func runUnprotectRepo(owner, repo string, rules []string) {
 	}
 	if r == nil {
 		log.Printf("repository not found: %s/%s", owner, repo)
+		return
+	}
+
+	supported, reason, err := repoSupportsProtection(ctx, client, r)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	if !supported {
+		log.Printf("Skipping %s (%s)", r.GetFullName(), reason)
 		return
 	}
 
@@ -175,6 +192,14 @@ func runUnprotectOrg(org string, includeForks bool, skipList []string, rules []s
 	for _, repo := range repos {
 		if !repo.GetPermissions().GetAdmin() {
 			log.Printf("Skipping %s (no admin permission)", repo.GetFullName())
+			continue
+		}
+		supported, reason, err := repoSupportsProtection(ctx, client, repo)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		if !supported {
+			log.Printf("Skipping %s (%s)", repo.GetFullName(), reason)
 			continue
 		}
 		if skipRepos.Has(repo.GetName()) {


### PR DESCRIPTION
## Summary
- skip protect and unprotect operations for repos that do not support branch protection or rulesets
- allow changes only for public repos or repos owned by paid GitHub organizations
- reuse a shared eligibility check across bulk, org, and repo command variants
- avoid GitHub plan errors for private repos in free organizations and private user-owned repos

## Validation
- go test ./cmds/...
- go test ./...
